### PR TITLE
Fix appmenus: gnome-terminal and gpk-update-viewer

### DIFF
--- a/template_scripts/appmenus_centos7/netvm-whitelisted-appmenus.list
+++ b/template_scripts/appmenus_centos7/netvm-whitelisted-appmenus.list
@@ -1,1 +1,1 @@
-gnome-terminal.desktop
+org.gnome.Terminal.desktop

--- a/template_scripts/appmenus_centos7/vm-whitelisted-appmenus.list
+++ b/template_scripts/appmenus_centos7/vm-whitelisted-appmenus.list
@@ -1,3 +1,3 @@
-gnome-terminal.desktop
+org.gnome.Terminal.desktop
 org.gnome.Nautilus.desktop
 firefox.desktop

--- a/template_scripts/appmenus_centos7/whitelisted-appmenus.list
+++ b/template_scripts/appmenus_centos7/whitelisted-appmenus.list
@@ -1,4 +1,4 @@
-gnome-terminal.desktop
+org.gnome.Terminal.desktop
 org.gnome.Software.desktop
-gpk-update-viewer.desktop
+org.gnome.PackageUpdater.desktop
 gnome-control-center.desktop


### PR DESCRIPTION
Revert to the original change of Terminal desktop name (probably updates) and fix gpk-update-viewer desktop name